### PR TITLE
Improving zip strides error message

### DIFF
--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -2481,7 +2481,7 @@ auto zip
         static assert(isSlice!S == packs, "zip: all Slices must have the same shape packs");
         assert(slices[i + 1]._lengths == slices[0]._lengths, "zip: all slices must have the same lengths");
         static if (sameStrides)
-            assert(slices[i + 1].unpack.strides == slices[0].unpack.strides, "zip: all slices must have the same strides");
+            assert(slices[i + 1].unpack.strides == slices[0].unpack.strides, "zip: all slices must have the same strides when unpacked");
     }
     static if (!sameStrides && minElem(staticMap!(kindOf, Slices)) != Contiguous)
     {


### PR DESCRIPTION
The way the strides error message work is that two slices could have the same strides when packed and it could trigger. Just making the error message more clear that the slices need to have the same strides when unpacked.